### PR TITLE
[FEAT] v.0.0.1 -> v.0.1.0

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useBoolean } from "./useBoolean";
 export { usePrevious } from "./usePrevious";
 export { useOutsideClick } from "./useOutsideClick";
 export { useMediaQuery } from "./useMediaQuery";
+export { useWindowSize } from "./useWindowSize";

--- a/src/hooks/useWindowSize/index.ts
+++ b/src/hooks/useWindowSize/index.ts
@@ -1,0 +1,1 @@
+export { useWindowSize } from "./useWindowSize";

--- a/src/hooks/useWindowSize/useWindowSize.test.ts
+++ b/src/hooks/useWindowSize/useWindowSize.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useWindowSize } from "./useWindowSize";
+
+describe("useWindowSize", () => {
+  const triggerResize = (width: number, height: number) => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      configurable: true,
+      value: height,
+    });
+    window.dispatchEvent(new Event("resize"));
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      configurable: true,
+      value: 768,
+    });
+  });
+
+  it("초기 창 크기를 반환한다", () => {
+    const { result } = renderHook(() => useWindowSize());
+    expect(result.current.width).toBe(1024);
+    expect(result.current.height).toBe(768);
+  });
+
+  it("창 크기가 변경되면 업데이트된다", () => {
+    const { result } = renderHook(() => useWindowSize());
+
+    act(() => {
+      triggerResize(375, 812);
+    });
+
+    expect(result.current.width).toBe(375);
+    expect(result.current.height).toBe(812);
+  });
+
+  it("언마운트 시 이벤트 리스너가 정리된다", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useWindowSize());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+    );
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/src/hooks/useWindowSize/useWindowSize.ts
+++ b/src/hooks/useWindowSize/useWindowSize.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Tracks the current browser window dimensions reactively.
+ *
+ * @returns { width, height } — current window size in pixels
+ *
+ * @example
+ * const { width, height } = useWindowSize();
+ *
+ * if (width < 768) {
+ *   return <MobileLayout />;
+ * }
+ */
+export function useWindowSize(): WindowSize {
+  const getSize = (): WindowSize => {
+    if (typeof window === "undefined") {
+      return { width: 0, height: 0 };
+    }
+    return {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+  };
+
+  const [size, setSize] = useState<WindowSize>(getSize);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleResize = () => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return size;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export {
   usePrevious,
   useOutsideClick,
   useMediaQuery,
+  useWindowSize,
 } from "./hooks";


### PR DESCRIPTION
## 개요

`v.0.0.1` -> `v.0.1.0`

## 관련 이슈

- Relates # (예시)

## 변경 유형

- [x] 새로운 훅 추가
- [ ] 버그 수정
- [ ] 기존 훅 수정
- [ ] 테스트
- [ ] 문서
- [ ] 설정 / 빌드

## 체크리스트

- [x] 테스트 작성 및 통과 (`pnpm test`)
- [x] 타입 체크 통과 (`pnpm lint`)
- [x] 빌드 통과 (`pnpm build`)
- [x] 신규 훅인 경우 `src/hooks/index.ts`, `src/index.ts`에 export 추가
- [x] Breaking Change가 있는 경우 아래에 명시

## 릴리즈

### 버전 업 유형

```
minor
```

### 변경 내용

- useWindowSize 훅 추가
  : 브라우저 창의 width, height를 실시간으로 추적하는 훅
  : SSR(Next.js) 환경에서 window가 없는 경우 `{ width: 0, height: 0 }` 반환
