### PR TITLE
[Feature] useCopyToClipboard 훅 제작

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -6,6 +6,7 @@ import {
   usePrevious,
   useMediaQuery,
   useLocalStorage,
+  useCopyToClipboard,
 } from "react-ssutil";
 
 const styles = {
@@ -240,6 +241,40 @@ function LocalStorageDemo() {
   );
 }
 
+function CopyToClipboardDemo() {
+  const [input, setInput] = useState("복사할 텍스트를 입력하세요");
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+
+  const { copy } = useCopyToClipboard({
+    onSuccess: () => setStatus("success"),
+    onError: () => setStatus("error"),
+  });
+
+  const handleCopy = useCallback(async () => {
+    setStatus("idle");
+    await copy(input);
+  }, [copy, input]);
+
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionTitle}>useCopyToClipboard</div>
+      <div style={styles.row}>
+        <input
+          style={{ ...styles.input, marginBottom: 0, flex: 1 }}
+          value={input}
+          onChange={(e) => { setInput(e.target.value); setStatus("idle"); }}
+        />
+        <button style={styles.button} onClick={handleCopy}>복사</button>
+      </div>
+      {status !== "idle" && (
+        <div style={{ ...styles.log, marginTop: 12, color: status === "success" ? "#4ade80" : "#ef4444" }}>
+          {status === "success" ? "클립보드에 복사되었습니다" : "복사에 실패했습니다"}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <div style={styles.app}>
@@ -255,6 +290,7 @@ export default function App() {
       <PreviousDemo />
       <MediaQueryDemo />
       <LocalStorageDemo />
+      <CopyToClipboardDemo />
     </div>
   );
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useOutsideClick } from "./useOutsideClick";
 export { useMediaQuery } from "./useMediaQuery";
 export { useWindowSize } from "./useWindowSize";
 export { useIntersectionObserver } from "./useIntersectionObserver";
+export { useCopyToClipboard } from "./useCopyToClipboard";

--- a/src/hooks/useCopyToClipboard/index.ts
+++ b/src/hooks/useCopyToClipboard/index.ts
@@ -1,0 +1,1 @@
+export { useCopyToClipboard } from "./useCopyToClipboard";

--- a/src/hooks/useCopyToClipboard/useCopyToClipboard.test.ts
+++ b/src/hooks/useCopyToClipboard/useCopyToClipboard.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useCopyToClipboard } from "./useCopyToClipboard";
+
+const mockWriteText = vi.fn();
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: mockWriteText },
+    });
+    vi.stubGlobal("isSecureContext", true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("Clipboard API로 복사 성공 시 true를 반환하고 onSuccess를 호출한다", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useCopyToClipboard({ onSuccess, onError }));
+
+    let returnValue: boolean;
+    await act(async () => {
+      returnValue = await result.current.copy("복사할 텍스트");
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith("복사할 텍스트");
+    expect(returnValue!).toBe(true);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("Clipboard API 실패 시 false를 반환하고 onError를 호출한다", async () => {
+    const error = new Error("clipboard 실패");
+    mockWriteText.mockRejectedValue(error);
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useCopyToClipboard({ onSuccess, onError }));
+
+    let returnValue: boolean;
+    await act(async () => {
+      returnValue = await result.current.copy("복사할 텍스트");
+    });
+
+    expect(returnValue!).toBe(false);
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("비보안 컨텍스트에서 textarea 폴백을 사용한다", async () => {
+    vi.stubGlobal("isSecureContext", false);
+
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      writable: true,
+      configurable: true,
+    });
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() => useCopyToClipboard({ onSuccess }));
+
+    await act(async () => {
+      await result.current.copy("폴백 텍스트");
+    });
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(mockWriteText).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("onSuccess, onError가 없어도 오류 없이 동작한다", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await expect(result.current.copy("텍스트")).resolves.toBe(true);
+    });
+  });
+});

--- a/src/hooks/useCopyToClipboard/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard/useCopyToClipboard.ts
@@ -1,0 +1,67 @@
+import { useCallback } from "react";
+
+interface UseCopyToClipboardParams {
+  onSuccess?: () => void;
+  onError?: (err: unknown) => void;
+}
+
+interface UseCopyToClipboardReturn {
+  copy: (text: string) => Promise<boolean>;
+}
+
+/**
+ * 텍스트를 클립보드에 복사하는 훅
+ *
+ * 보안 컨텍스트(HTTPS)에서는 Clipboard API를 사용하고,
+ * 그 외 환경에서는 textarea + execCommand 폴백을 사용합니다.
+ *
+ * @param onSuccess - 복사 성공 시 실행할 콜백 (선택)
+ * @param onError - 복사 실패 시 실행할 콜백 (선택)
+ * @returns { copy } - 복사 함수, 성공 여부를 boolean으로 반환
+ *
+ * @example
+ * const { copy } = useCopyToClipboard({
+ *   onSuccess: () => toast('복사되었습니다'),
+ *   onError: () => toast.error('복사에 실패했습니다'),
+ * });
+ * return <button onClick={() => copy('복사할 텍스트')}>복사</button>;
+ */
+export function useCopyToClipboard({
+  onSuccess,
+  onError,
+}: UseCopyToClipboardParams = {}): UseCopyToClipboardReturn {
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      try {
+        // 브라우저가 Clipboard API를 지원하고, 현재 페이지가 보안 컨텍스트(HTTPS)인 경우
+        if (
+          typeof navigator !== "undefined" &&
+          navigator.clipboard &&
+          window.isSecureContext
+        ) {
+          // 비동기로 동작하며 깔끔하게 텍스트를 복사할 수 있습니다.
+          await navigator.clipboard.writeText(text);
+        } else {
+          // fallback: HTTPS가 아닌 환경 대응
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.setAttribute("readonly", "");
+          textarea.style.cssText = "position:fixed;left:-9999px";
+          document.body.appendChild(textarea);
+          textarea.select();
+          // deprecated이지만 비보안 컨텍스트 폴백으로 의도적으로 사용
+          document.execCommand("copy");
+          document.body.removeChild(textarea);
+        }
+        onSuccess?.();
+        return true;
+      } catch (err) {
+        onError?.(err);
+        return false;
+      }
+    },
+    [onSuccess, onError]
+  );
+
+  return { copy };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export {
   useMediaQuery,
   useWindowSize,
   useIntersectionObserver,
+  useCopyToClipboard,
 } from "./hooks";


### PR DESCRIPTION
## 개요

다양한 브라우저 환경에서 안정적으로 동작하는 `클립보드 복사 유틸리티 훅`인 `useCopyToClipboard`를 추가합니다.

## 관련 이슈

- Closes #8

## 변경 유형

- [x] 새로운 훅 추가
- [ ] 버그 수정
- [ ] 기존 훅 수정
- [x] 테스트
- [ ] 문서
- [ ] 설정 / 빌드

## 체크리스트

- [x] 테스트 작성 및 통과 (`pnpm test`)
- [x] 타입 체크 통과 (`pnpm lint`)
- [x] 빌드 통과 (`pnpm build`)
- [x] 신규 훅인 경우 `src/hooks/index.ts`, `src/index.ts`에 export 추가

---

### 버전 업 유형

```
minor
```

### 변경 내용

- useCopyToClipboard — Copies text to the clipboard with fallback support for non-secure contexts (HTTP) and legacy browsers.