### PR TITLE
[Refactor]: useLocalStorage Test 추가 및 Bug 해결

### DIFF
--- a/src/hooks/useLocalStorage/useLocalStorage.test.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.test.ts
@@ -1,0 +1,235 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLocalStorage } from './useLocalStorage';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('초기값', () => {
+    it('localStorage 가 비어있으면 initialValue 를 반환한다', () => {
+      const { result } = renderHook(() => useLocalStorage('key', 'default'));
+      const [value] = result.current;
+      expect(value).toBe('default');
+    });
+
+    it('localStorage 에 값이 있으면 그 값을 우선한다', () => {
+      window.localStorage.setItem('key', JSON.stringify('stored'));
+      const { result } = renderHook(() => useLocalStorage('key', 'default'));
+      const [value] = result.current;
+      expect(value).toBe('stored');
+    });
+
+    it('객체/배열 같은 복합 타입도 정상 직렬화된다', () => {
+      const initial = { count: 0, tags: ['a', 'b'] };
+      const { result } = renderHook(() => useLocalStorage('obj', initial));
+      const [value, setValue] = result.current;
+      expect(value).toEqual(initial);
+
+      act(() => setValue({ count: 1, tags: ['c'] }));
+      expect(JSON.parse(window.localStorage.getItem('obj')!)).toEqual({
+        count: 1,
+        tags: ['c'],
+      });
+    });
+  });
+
+  describe('setValue', () => {
+    it('값을 직접 설정하고 localStorage 에도 반영된다', () => {
+      const { result } = renderHook(() => useLocalStorage('key', 'a'));
+      const [, setValue] = result.current;
+      act(() => setValue('b'));
+      const [value] = result.current;
+      expect(value).toBe('b');
+      expect(window.localStorage.getItem('key')).toBe(JSON.stringify('b'));
+    });
+
+    it('함수형 업데이트가 이전 값을 받는다', () => {
+      const { result } = renderHook(() => useLocalStorage('count', 10));
+      const [, setValue] = result.current;
+      act(() => setValue((prev) => prev + 5));
+      const [value] = result.current;
+      expect(value).toBe(15);
+    });
+
+    // regression: storedValue 를 useCallback deps 에 넣으면 같은 렌더 사이클의
+    // 연속 함수형 업데이트가 stale 한 값을 참조해 마지막 호출 결과만 남는 버그.
+    // storedValueRef 로 즉시 갱신하여 수정.
+    it('[regression] 같은 렌더 사이클의 연속 함수형 업데이트가 누적된다', () => {
+      const { result } = renderHook(() => useLocalStorage('count', 0));
+      act(() => {
+        const [, setValue] = result.current;
+        setValue((p) => p + 1);
+        setValue((p) => p + 1);
+        setValue((p) => p + 1);
+      });
+      const [value] = result.current;
+      expect(value).toBe(3);
+      expect(window.localStorage.getItem('count')).toBe('3');
+    });
+
+    // regression: storedValue 가 deps 에 있으면 값이 바뀔 때마다 setValue 참조가
+    // 교체되어 React.memo / useEffect deps 에 넣은 컴포넌트가 불필요하게 재실행됨.
+    it('[regression] setValue 참조는 값이 바뀌어도 안정적이다', () => {
+      const { result } = renderHook(() => useLocalStorage('key', 'a'));
+      const [, setValueBefore] = result.current;
+
+      act(() => setValueBefore('b'));
+
+      const [value, setValueAfter] = result.current;
+      expect(value).toBe('b');
+      expect(setValueAfter).toBe(setValueBefore);
+    });
+  });
+
+  describe('removeValue', () => {
+    it('localStorage 에서 키를 제거하고 initialValue 로 복귀한다', () => {
+      const { result } = renderHook(() => useLocalStorage('key', 'default'));
+      const [, setValue, removeValue] = result.current;
+      act(() => setValue('changed'));
+      expect(result.current[0]).toBe('changed');
+
+      act(() => removeValue());
+      const [value] = result.current;
+      expect(value).toBe('default');
+      expect(window.localStorage.getItem('key')).toBeNull();
+    });
+  });
+
+  describe('같은 탭 내 동기화', () => {
+    it('같은 키를 쓰는 두 인스턴스가 동기화된다', () => {
+      const a = renderHook(() => useLocalStorage('shared', 0));
+      const b = renderHook(() => useLocalStorage('shared', 0));
+
+      act(() => a.result.current[1](42));
+      expect(b.result.current[0]).toBe(42);
+    });
+
+    it('removeValue 도 다른 인스턴스에 전파된다', () => {
+      const a = renderHook(() => useLocalStorage('shared', 'init'));
+      const b = renderHook(() => useLocalStorage('shared', 'init'));
+
+      act(() => a.result.current[1]('changed'));
+      expect(b.result.current[0]).toBe('changed');
+
+      act(() => a.result.current[2]());
+      expect(b.result.current[0]).toBe('init');
+    });
+  });
+
+  describe('다른 탭 동기화 (storage 이벤트)', () => {
+    it("'storage' 이벤트가 오면 값이 갱신된다", () => {
+      const { result } = renderHook(() => useLocalStorage('key', 'init'));
+
+      act(() => {
+        window.localStorage.setItem('key', JSON.stringify('from-other-tab'));
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'key',
+            newValue: JSON.stringify('from-other-tab'),
+            storageArea: window.localStorage,
+          }),
+        );
+      });
+
+      const [value] = result.current;
+      expect(value).toBe('from-other-tab');
+    });
+  });
+
+  // regression: 이전 구현은 catch 블록이 비어있어 quota 초과 / 파싱 실패 /
+  // 사파리 시크릿 모드 등 모든 에러가 조용히 묻혔음. onError 옵션으로 노출.
+  describe('에러 처리', () => {
+    it('파싱 실패 시 initialValue 로 fallback 한다', () => {
+      window.localStorage.setItem('key', 'NOT_VALID_JSON{{{');
+      const { result } = renderHook(() => useLocalStorage('key', 'fallback'));
+      const [value] = result.current;
+      expect(value).toBe('fallback');
+    });
+
+    it('파싱 실패 시 onError 가 호출된다', () => {
+      window.localStorage.setItem('key', 'INVALID_JSON');
+      const onError = vi.fn();
+      renderHook(() => useLocalStorage('key', 'fallback', { onError }));
+      expect(onError).toHaveBeenCalled();
+      expect(onError.mock.calls[0][0]).toBeInstanceOf(SyntaxError);
+    });
+
+    it('onError 가 없으면 console.warn 으로 출력한다', () => {
+      window.localStorage.setItem('key', 'INVALID_JSON');
+      renderHook(() => useLocalStorage('key', 'fallback'));
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it('setItem 이 실패해도 (e.g. quota exceeded) 앱이 죽지 않고 onError 가 호출된다', () => {
+      const onError = vi.fn();
+      const realStorage = window.localStorage;
+      vi.stubGlobal('localStorage', {
+        ...realStorage,
+        getItem: realStorage.getItem.bind(realStorage),
+        setItem: () => {
+          throw new DOMException('Quota exceeded', 'QuotaExceededError');
+        },
+        removeItem: realStorage.removeItem.bind(realStorage),
+        clear: realStorage.clear.bind(realStorage),
+        key: realStorage.key.bind(realStorage),
+        get length() {
+          return realStorage.length;
+        },
+      } as Storage);
+
+      const { result } = renderHook(() => useLocalStorage('key', 'init', { onError }));
+      expect(() => {
+        act(() => result.current[1]('large-value'));
+      }).not.toThrow();
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('removeItem 이 실패해도 앱이 죽지 않고 onError 가 호출된다', () => {
+      const onError = vi.fn();
+      const realStorage = window.localStorage;
+      vi.stubGlobal('localStorage', {
+        ...realStorage,
+        getItem: realStorage.getItem.bind(realStorage),
+        setItem: realStorage.setItem.bind(realStorage),
+        removeItem: () => {
+          throw new Error('Some storage error');
+        },
+        clear: realStorage.clear.bind(realStorage),
+        key: realStorage.key.bind(realStorage),
+        get length() {
+          return realStorage.length;
+        },
+      } as Storage);
+
+      const { result } = renderHook(() => useLocalStorage('key', 'init', { onError }));
+      expect(() => {
+        act(() => result.current[2]());
+      }).not.toThrow();
+      expect(onError).toHaveBeenCalled();
+    });
+  });
+
+  describe('key 변경', () => {
+    it('key 가 바뀌면 새 키의 값을 읽는다', () => {
+      window.localStorage.setItem('key-a', JSON.stringify('value-a'));
+      window.localStorage.setItem('key-b', JSON.stringify('value-b'));
+
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalStorage(k, 'default'),
+        { initialProps: { k: 'key-a' } },
+      );
+      expect(result.current[0]).toBe('value-a');
+
+      rerender({ k: 'key-b' });
+      expect(result.current[0]).toBe('value-b');
+    });
+  });
+});

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,67 +1,96 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef, useLayoutEffect } from 'react';
 
 type SetValue<T> = (value: T | ((prev: T) => T)) => void;
+
+export interface UseLocalStorageOptions {
+  /** 직렬화/storage 접근 에러 콜백. 미지정 시 console.warn 으로 출력. */
+  onError?: (error: unknown) => void;
+}
 
 /**
  * localStorage와 동기화되는 상태 관리 훅
  *
  * @param key - localStorage 키
  * @param initialValue - 초기값 (localStorage에 값이 없을 때 사용)
+ * @param options - 에러 핸들러 등 옵션
  * @returns [storedValue, setValue, removeValue] 튜플
- *
  * @example
  * const [theme, setTheme, removeTheme] = useLocalStorage("theme", "light");
  */
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T
+  initialValue: T,
+  options: UseLocalStorageOptions = {},
 ): [T, SetValue<T>, () => void] {
+  const { onError } = options;
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      if (onError) {
+        onError(error);
+      } else {
+        console.warn(`[useLocalStorage] key="${key}":`, error);
+      }
+    },
+    [key, onError],
+  );
+
   const readValue = useCallback((): T => {
-    if (typeof window === "undefined") {
+    if (typeof window === 'undefined') {
       return initialValue;
     }
     try {
       const item = window.localStorage.getItem(key);
       return item !== null ? (JSON.parse(item) as T) : initialValue;
-    } catch {
+    } catch (error) {
+      handleError(error);
       return initialValue;
     }
-  }, [key, initialValue]);
+  }, [key, initialValue, handleError]);
 
   const [storedValue, setStoredValue] = useState<T>(readValue);
 
+  // storedValue 를 deps 에 넣으면 stale closure + setValue 참조 불안정 문제가 생겨 ref 로 미러링.
+  // 렌더 중 ref 직접 할당은 Concurrent Mode 에서 권장되지 않으므로 useLayoutEffect 로 동기화.
+  // useEffect 가 아닌 useLayoutEffect 를 쓰는 이유: paint 전에 ref 가 갱신되어야
+  // 같은 사이클 내에서 ref 를 읽는 코드가 stale 한 값을 보지 않도록 보장.
+  const storedValueRef = useRef<T>(storedValue);
+  useLayoutEffect(() => {
+    storedValueRef.current = storedValue;
+  }, [storedValue]);
+
   const setValue: SetValue<T> = useCallback(
     (value) => {
-      if (typeof window === "undefined") {
+      if (typeof window === 'undefined') {
         return;
       }
       try {
         const nextValue =
-          typeof value === "function"
-            ? (value as (prev: T) => T)(storedValue)
-            : value;
+          typeof value === 'function' ? (value as (prev: T) => T)(storedValueRef.current) : value;
+        storedValueRef.current = nextValue;
         window.localStorage.setItem(key, JSON.stringify(nextValue));
         setStoredValue(nextValue);
-        window.dispatchEvent(new Event("local-storage"));
-      } catch {
-        // do nothing
+        window.dispatchEvent(new Event('local-storage'));
+      } catch (error) {
+        handleError(error);
       }
     },
-    [key, storedValue]
+    [key, handleError],
   );
 
   const removeValue = useCallback(() => {
-    if (typeof window === "undefined") {
+    if (typeof window === 'undefined') {
       return;
     }
     try {
       window.localStorage.removeItem(key);
+      storedValueRef.current = initialValue;
       setStoredValue(initialValue);
-      window.dispatchEvent(new Event("local-storage"));
-    } catch {
-      // do nothing
+      window.dispatchEvent(new Event('local-storage'));
+    } catch (error) {
+      handleError(error);
     }
-  }, [key, initialValue]);
+  }, [key, initialValue, handleError]);
 
   useEffect(() => {
     setStoredValue(readValue());
@@ -71,11 +100,11 @@ export function useLocalStorage<T>(
     const handleStorageChange = () => {
       setStoredValue(readValue());
     };
-    window.addEventListener("storage", handleStorageChange);
-    window.addEventListener("local-storage", handleStorageChange);
+    window.addEventListener('storage', handleStorageChange);
+    window.addEventListener('local-storage', handleStorageChange);
     return () => {
-      window.removeEventListener("storage", handleStorageChange);
-      window.removeEventListener("local-storage", handleStorageChange);
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('local-storage', handleStorageChange);
     };
   }, [readValue]);
 


### PR DESCRIPTION
## 개요

<!-- 이 PR이 무엇을 하는지 간략하게 설명해주세요. -->
- `useLocalStorage 훅`의 `stale closure` 버그 수정 및 에러 핸들링을 개선합니다.

> setValue의 함수형 업데이트가 같은 렌더 사이클에서 연속 호출 시 누적되지 않는 버그를 useRef 미러링으로 해결하고, ref 동기화를 useLayoutEffect로 수행하여 Concurrent Mode 안전성을 확보했습니다.

> 모든 catch {} 블록이 에러를 silent하게 삼키던 문제를 onError 옵션 및 console.warn fallback으로 개선했습니다.

## 관련 이슈

<!-- 관련 이슈가 있다면 연결해주세요. -->

- Closes #

## 변경 유형

- [ ] 새로운 훅 추가
- [x] 버그 수정
- [x] 기존 훅 수정
- [ ] 테스트
- [ ] 문서
- [ ] 설정 / 빌드

## 체크리스트

- [x] 테스트 작성 및 통과 (`pnpm test`)
- [x] 타입 체크 통과 (`pnpm lint`)
- [x] 빌드 통과 (`pnpm build`)
- [x] 신규 훅인 경우 `src/hooks/index.ts`, `src/index.ts`에 export 추가
- [x] Breaking Change가 있는 경우 아래에 명시

## Breaking Change

<!-- Breaking Change가 있다면 설명해주세요. 없으면 삭제하세요. -->

---

## 릴리즈

<!-- main 브랜치로 머지할 때 작성해주세요. dev 브랜치 PR은 비워두셔도 됩니다. -->

### 버전 업 유형

<!-- 하나만 선택해주세요: patch | minor | major -->
<!-- patch: 버그 수정, 설정 변경 (0.0.x) -->
<!-- minor: 새 훅 추가, 기능 추가 (0.x.0) -->
<!-- major: Breaking Change (x.0.0) -->

```
patch
```

### 변경 내용

<!-- CHANGELOG.md와 GitHub Release에 기록될 내용입니다. -->
<!-- 주요 변경 사항을 bullet로 작성해주세요. -->

- useLocalStorage: 같은 렌더 사이클의 연속 함수형 업데이트가 누적되지 않는 stale closure 버그 수정 (useRef 미러링 + useLayoutEffect 동기화)
- useLocalStorage: setValue 참조가 값 변경 시마다 새로 생성되던 문제 수정 (deps에서 storedValue 제거)
- useLocalStorage: onError 옵션 추가 — storage 에러를 silent하게 삼키지 않고 사용자에게 노출 (미지정 시 console.warn fallback)
- useLocalStorage: 회귀 방지 테스트 추가 (연속 함수형 업데이트 누적, setValue 참조 안정성, 에러 처리 5개)
