### PR TITLE
[Feature]: 특정 날짜까지의 D-DAY를 계산하는 훅 'useDDay'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.0] - 2026-04-27
+
+> PR #7 — [FEAT] v.0.0.4 -> v.0.1.0
+
+- useIntersectionObserver 훅 추가
+
+---
+
 ## [0.0.4] - 2026-04-27
 
 > PR #4 — [FIX] v.0.0.3 -> v.0.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.4] - 2026-04-27
+
+> PR #4 — [FIX] v.0.0.3 -> v.0.0.4
+
+- release workflow 파싱 버그 수정
+  : changelog에 백틱, 따옴표 등 특수문자 포함 시 GitHub Actions 스크립트 구문 에러 발생하던 문제 수정
+  : 동적 값을 env 블록으로 분리하여 process.env / os.environ으로 안전하게 읽도록 개선
+
+---
+
 ## [$VERSION] - $DATE
 
 > PR #$PR_NUMBER — $PR_TITLE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ssutil",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A collection of useful React hooks for React, Next.js, and Vue.js (React adapter) environments.",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ssutil",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A collection of useful React hooks for React, Next.js, and Vue.js (React adapter) environments.",
   "keywords": [
     "react",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useOutsideClick } from "./useOutsideClick";
 export { useMediaQuery } from "./useMediaQuery";
 export { useWindowSize } from "./useWindowSize";
 export { useIntersectionObserver } from "./useIntersectionObserver";
+export {useDDay} from "./useDDay";

--- a/src/hooks/useDDay/index.ts
+++ b/src/hooks/useDDay/index.ts
@@ -1,0 +1,1 @@
+export { useDDay } from "./useDDay";

--- a/src/hooks/useDDay/useDDay.test.ts
+++ b/src/hooks/useDDay/useDDay.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDDay } from "./useDDay";
+
+/**
+ * 현재 날짜를 고정하는 헬퍼
+ * @param dateString - 고정할 날짜 "YYYY-MM-DD"
+ */
+function mockToday(dateString: string) {
+  vi.setSystemTime(new Date(dateString));
+}
+
+describe("useDDay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("inclusive: true (default)", () => {
+    it("당일이면 dDay가 0이고 label이 'D-DAY'여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-06-01"));
+
+      expect(result.current.dDay).toBe(0);
+      expect(result.current.label).toBe("D-DAY");
+      expect(result.current.isPast).toBe(false);
+    });
+
+    it("미래 날짜면 양수 dDay와 'D-{n}' label을 반환해야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-06-11"));
+
+      expect(result.current.dDay).toBe(10);
+      expect(result.current.label).toBe("D-10");
+      expect(result.current.isPast).toBe(false);
+    });
+
+    it("과거 날짜면 음수 dDay와 'D+{n}' label을 반환해야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-05-29"));
+
+      expect(result.current.dDay).toBe(-3);
+      expect(result.current.label).toBe("D+3");
+      expect(result.current.isPast).toBe(true);
+    });
+
+    it("내일이면 dDay가 1이어야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-06-02"));
+
+      expect(result.current.dDay).toBe(1);
+      expect(result.current.label).toBe("D-1");
+    });
+
+    it("어제면 dDay가 -1이어야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-05-31"));
+
+      expect(result.current.dDay).toBe(-1);
+      expect(result.current.label).toBe("D+1");
+      expect(result.current.isPast).toBe(true);
+    });
+  });
+
+  describe("inclusive: false", () => {
+    it("당일이면 dDay가 -1이고 label이 'D+1'이어야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() =>
+        useDDay("2025-06-01", { inclusive: false })
+      );
+
+      expect(result.current.dDay).toBe(-1);
+      expect(result.current.label).toBe("D+1");
+      expect(result.current.isPast).toBe(true);
+    });
+
+    it("내일이면 dDay가 0이고 label이 'D-DAY'여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() =>
+        useDDay("2025-06-02", { inclusive: false })
+      );
+
+      expect(result.current.dDay).toBe(0);
+      expect(result.current.label).toBe("D-DAY");
+      expect(result.current.isPast).toBe(false);
+    });
+
+    it("10일 뒤면 dDay가 9여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() =>
+        useDDay("2025-06-11", { inclusive: false })
+      );
+
+      expect(result.current.dDay).toBe(9);
+      expect(result.current.label).toBe("D-9");
+    });
+  });
+
+  describe("입력 타입", () => {
+    it("string 타입 날짜를 받을 수 있어야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-06-11"));
+
+      expect(result.current.dDay).toBe(10);
+    });
+
+    it("Date 객체를 받을 수 있어야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay(new Date("2025-06-11")));
+
+      expect(result.current.dDay).toBe(10);
+    });
+  });
+
+  describe("isPast", () => {
+    it("미래 날짜면 isPast가 false여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-12-31"));
+
+      expect(result.current.isPast).toBe(false);
+    });
+
+    it("과거 날짜면 isPast가 true여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-01-01"));
+
+      expect(result.current.isPast).toBe(true);
+    });
+
+    it("당일(inclusive: true)이면 isPast가 false여야 한다", () => {
+      mockToday("2025-06-01");
+      const { result } = renderHook(() => useDDay("2025-06-01"));
+
+      expect(result.current.isPast).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useDDay/useDDay.ts
+++ b/src/hooks/useDDay/useDDay.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+
+export interface UseDDayOptions {
+  /**
+   * 목표 날짜 당일을 D-DAY(0)로 포함할지 여부
+   * - `true` (default): 당일 → D-DAY
+   * - `false`: 당일 → D-1, 다음날 → D-DAY
+   */
+  inclusive?: boolean;
+}
+
+export interface UseDDayReturn {
+  /**
+   * 목표 날짜까지 남은 일수
+   * - 양수: 미래 (D-{n})
+   * - 0: 당일 (D-DAY)
+   * - 음수: 과거 (D+{n})
+   */
+  dDay: number;
+  /**
+   * 포맷된 D-DAY 문자열
+   * @example "D-DAY" | "D-10" | "D+3"
+   */
+  label: string;
+  /** 목표 날짜가 오늘보다 이전인지 여부 */
+  isPast: boolean;
+}
+
+/**
+ * 목표 날짜까지의 D-DAY를 계산하는 훅
+ *
+ * 브라우저의 현재 날짜를 기준으로 목표 날짜까지 남은 일수를 계산하고,
+ * "D-DAY", "D-10", "D+3" 형태의 포맷된 문자열을 반환합니다.
+ *
+ * @param targetDate - 목표 날짜 (string: "YYYY-MM-DD" 형식 또는 Date 객체)
+ * @param options - 옵션
+ * @param options.inclusive - 당일을 D-DAY로 포함할지 여부 (default: true)
+ * @returns `{ dDay, label, isPast }`
+ *
+ * @example
+ * // 기본 사용 (당일 포함)
+ * const { dDay, label, isPast } = useDDay("2025-12-25");
+ * // dDay: 10, label: "D-10", isPast: false
+ *
+ * @example
+ * // 당일 미포함
+ * const { label } = useDDay("2025-12-25", { inclusive: false });
+ * // 당일: label → "D-1"
+ *
+ * @example
+ * // Date 객체로도 사용 가능
+ * const { label } = useDDay(new Date("2025-12-25"));
+ */
+export function useDDay(
+  targetDate: string | Date,
+  { inclusive = true }: UseDDayOptions = {}
+): UseDDayReturn {
+  return useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const target = new Date(targetDate);
+    target.setHours(0, 0, 0, 0);
+
+    const diffMs = target.getTime() - today.getTime();
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+    const dDay = inclusive ? diffDays : diffDays - 1;
+
+    const label =
+      dDay === 0
+        ? "D-DAY"
+        : dDay > 0
+          ? `D-${dDay}`
+          : `D+${Math.abs(dDay)}`;
+
+    return {
+      dDay,
+      label,
+      isPast: dDay < 0,
+    };
+  }, [targetDate, inclusive]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export {
   useMediaQuery,
   useWindowSize,
   useIntersectionObserver,
+  useDDay,
 } from "./hooks";


### PR DESCRIPTION
## 개요

- `useDDay` 훅 추가
- 목표 날짜까지 남은 일수(`dDay`), 포맷 문자열(`label`), 과거 여부(`isPast`) 반환
- `inclusive` 옵션으로 당일 포함 여부 설정 가능 (default: `true`)
- `string` / `Date` 타입 모두 지원

## 관련 이슈

- Closes #17

### 사용 예시
<img width="325" height="82" alt="image" src="https://github.com/user-attachments/assets/93e371a7-f10a-4848-9d89-57a456b46ee3" />
DDAY를 표시하는 배너 등

이거 배포되면 총홈에 적용하러 갑니다~! ㅋㅋ

## 변경 유형

- [x] 새로운 훅 추가
- [ ] 버그 수정
- [ ] 기존 훅 수정
- [x] 테스트
- [ ] 문서
- [ ] 설정 / 빌드

## 체크리스트

- [x] pclea테스트 작성 및 통과 (`pnpm test`)
- [x] 타입 체크 통과 (`pnpm lint`)
- [x] 빌드 통과 (`pnpm build`)
- [x] 신규 훅인 경우 `src/hooks/index.ts`, `src/index.ts`에 export 추가
- [x] Breaking Change가 있는 경우 아래에 명시