### PR TITLE
[Feature]: useQueryState 훅 추가 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ yarn add react-ssutil
 | `useLocalStorage` | localStorage 동기화 상태 |
 | `useOutsideClick` | 외부 클릭 감지 |
 | `useMediaQuery` | CSS 미디어 쿼리 매칭 |
+| `useQueryState` | URL query string과 React state 동기화 |
 
 ## 사용법
 
@@ -151,6 +152,29 @@ function ResponsiveLayout() {
 }
 ```
 
+### useQueryState
+
+```tsx
+import { useQueryState } from "react-ssutil";
+
+function ProductList() {
+  const [page, setPage] = useQueryState("page", 1, {
+    parse: (value) => Number(value || 1),
+    serialize: (value) => String(value),
+  });
+  const [sort, setSort] = useQueryState("sort", "latest");
+
+  return (
+    <>
+      <button onClick={() => setSort("price")}>가격순</button>
+      <button onClick={() => setPage((prev) => prev + 1)}>다음 페이지</button>
+      <div>현재 페이지: {page}</div>
+      <div>정렬 기준: {sort}</div>
+    </>
+  );
+}
+```
+
 ## 개발 환경 실행
 
 ```bash
@@ -186,6 +210,7 @@ react-ssutil/
 │   │   ├── useLocalStorage/
 │   │   ├── useOutsideClick/
 │   │   ├── useMediaQuery/
+│   │   ├── useQueryState/
 │   │   └── index.ts
 │   └── index.ts
 ├── playground/          # React+TS 개발/테스트 환경

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,5 @@ export { useOutsideClick } from "./useOutsideClick";
 export { useMediaQuery } from "./useMediaQuery";
 export { useWindowSize } from "./useWindowSize";
 export { useIntersectionObserver } from "./useIntersectionObserver";
+export { useQueryState } from "./useQueryState";
+export type { UseQueryStateOptions } from "./useQueryState";

--- a/src/hooks/useQueryState/index.ts
+++ b/src/hooks/useQueryState/index.ts
@@ -1,0 +1,2 @@
+export { useQueryState } from "./useQueryState";
+export type { UseQueryStateOptions } from "./useQueryState";

--- a/src/hooks/useQueryState/useQueryState.test.ts
+++ b/src/hooks/useQueryState/useQueryState.test.ts
@@ -1,0 +1,232 @@
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useQueryState } from "./useQueryState";
+
+function TestSsrComponent() {
+  const [value] = useQueryState("page", 1, {
+    parse: (rawValue) => Number(rawValue),
+    serialize: (nextValue) => String(nextValue),
+  });
+
+  return createElement("span", null, value);
+}
+
+describe("useQueryState", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("초기 URL에 값이 있으면 해당 값을 읽는다", () => {
+    window.history.replaceState({}, "", "/?page=3");
+
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    expect(result.current[0]).toBe(3);
+  });
+
+  it("초기 URL에 값이 없으면 initialValue를 반환한다", () => {
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    expect(result.current[0]).toBe(1);
+  });
+
+  it("setValue(next) 호출 시 query param과 state가 함께 갱신된다", () => {
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      result.current[1](5);
+    });
+
+    expect(result.current[0]).toBe(5);
+    expect(window.location.search).toBe("?page=5");
+  });
+
+  it("updater 함수로 다음 값을 계산할 수 있다", () => {
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      result.current[1]((prev: number) => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(window.location.search).toBe("?page=2");
+  });
+
+  it("연속된 updater 함수 호출도 누적해서 처리한다", () => {
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      result.current[1]((prev: number) => prev + 1);
+      result.current[1]((prev: number) => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(3);
+    expect(window.location.search).toBe("?page=3");
+  });
+
+  it("다른 query param은 유지한다", () => {
+    window.history.replaceState({}, "", "/?sort=latest");
+
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      result.current[1](2);
+    });
+
+    expect(window.location.search).toBe("?sort=latest&page=2");
+  });
+
+  it("history가 replace일 때 replaceState를 호출한다", () => {
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
+
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      result.current[1](2);
+    });
+
+    expect(replaceStateSpy).toHaveBeenCalled();
+  });
+
+  it("history가 push일 때 pushState를 호출한다", () => {
+    const pushStateSpy = vi.spyOn(window.history, "pushState");
+
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+        history: "push",
+      }),
+    );
+
+    act(() => {
+      result.current[1](2);
+    });
+
+    expect(pushStateSpy).toHaveBeenCalled();
+  });
+
+  it("parse와 serialize로 boolean 값을 다룰 수 있다", () => {
+    window.history.replaceState({}, "", "/?open=true");
+
+    const { result } = renderHook(() =>
+      useQueryState("open", false, {
+        parse: (value) => value === "true",
+        serialize: (value) => String(value),
+      }),
+    );
+
+    expect(result.current[0]).toBe(true);
+
+    act(() => {
+      result.current[1](false);
+    });
+
+    expect(window.location.search).toBe("?open=false");
+  });
+
+  it("removeOn 조건이 만족되면 query param을 제거한다", () => {
+    window.history.replaceState({}, "", "/?page=2&sort=latest");
+
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+        removeOn: (value) => value === 1,
+      }),
+    );
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    expect(window.location.search).toBe("?sort=latest");
+  });
+
+  it("popstate 발생 시 URL 변경 내용을 반영한다", () => {
+    const { result } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    act(() => {
+      window.history.pushState({}, "", "/?page=4");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(result.current[0]).toBe(4);
+  });
+
+  it("SSR 환경에서는 initialValue를 반환한다", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(renderToString(createElement(TestSsrComponent))).toContain(">1<");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("언마운트 시 이벤트 리스너를 정리한다", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() =>
+      useQueryState("page", 1, {
+        parse: (value) => Number(value),
+        serialize: (value) => String(value),
+      }),
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "popstate",
+      expect.any(Function),
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "query-state",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/hooks/useQueryState/useQueryState.ts
+++ b/src/hooks/useQueryState/useQueryState.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type SetValue<T> = (value: T | ((prev: T) => T)) => void;
+
+export interface UseQueryStateOptions<T> {
+  parse?: (value: string) => T;
+  serialize?: (value: T) => string;
+  history?: "replace" | "push";
+  removeOn?: (value: T) => boolean;
+}
+
+const QUERY_STATE_EVENT = "query-state";
+
+const getSearchParams = () => new URLSearchParams(window.location.search);
+
+/**
+ * URL query string과 React state를 동기화하는 훅
+ *
+ * @param key - query string key
+ * @param initialValue - query 값이 없거나 파싱에 실패했을 때 사용할 기본값
+ * @param options - parse/serialize, history 모드, 제거 조건 옵션
+ * @returns [value, setValue] 튜플
+ *
+ * @example
+ * const [page, setPage] = useQueryState("page", 1, {
+ *   parse: (value) => Number(value || 1),
+ *   serialize: (value) => String(value),
+ * });
+ */
+export function useQueryState<T>(
+  key: string,
+  initialValue: T,
+  options: UseQueryStateOptions<T> = {},
+): [T, SetValue<T>] {
+  const {
+    parse = (value: string) => value as unknown as T,
+    serialize = (value: T) => String(value),
+    history = "replace",
+    removeOn,
+  } = options;
+
+  const readValue = useCallback((): T => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+
+    const rawValue = getSearchParams().get(key);
+
+    if (rawValue === null) {
+      return initialValue;
+    }
+
+    try {
+      return parse(rawValue);
+    } catch {
+      return initialValue;
+    }
+  }, [initialValue, key, parse]);
+
+  const [value, setStoredValue] = useState<T>(readValue);
+  const valueRef = useRef<T>(value);
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const setValue: SetValue<T> = useCallback(
+    (nextValue: T | ((prev: T) => T)) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      const resolvedValue =
+        typeof nextValue === "function"
+          ? (nextValue as (prev: T) => T)(valueRef.current)
+          : nextValue;
+
+      const params = getSearchParams();
+
+      if (removeOn?.(resolvedValue)) {
+        params.delete(key);
+      } else {
+        params.set(key, serialize(resolvedValue));
+      }
+
+      const nextSearch = params.toString();
+      const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`;
+      const historyMethod =
+        history === "push" ? window.history.pushState : window.history.replaceState;
+
+      historyMethod.call(window.history, window.history.state, "", nextUrl);
+      valueRef.current = resolvedValue;
+      setStoredValue(resolvedValue);
+      window.dispatchEvent(new Event(QUERY_STATE_EVENT));
+    },
+    [history, key, removeOn, serialize],
+  );
+
+  useEffect(() => {
+    setStoredValue(readValue());
+  }, [readValue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const syncFromUrl = () => {
+      setStoredValue(readValue());
+    };
+
+    window.addEventListener("popstate", syncFromUrl);
+    window.addEventListener(QUERY_STATE_EVENT, syncFromUrl);
+
+    return () => {
+      window.removeEventListener("popstate", syncFromUrl);
+      window.removeEventListener(QUERY_STATE_EVENT, syncFromUrl);
+    };
+  }, [readValue]);
+
+  return [value, setValue];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,6 @@ export {
   useMediaQuery,
   useWindowSize,
   useIntersectionObserver,
+  useQueryState,
 } from "./hooks";
+export type { UseQueryStateOptions } from "./hooks";

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,3 @@ export {
   useIntersectionObserver,
   useQueryState,
 } from "./hooks";
-export type { UseQueryStateOptions } from "./hooks";


### PR DESCRIPTION
## 개요

URL query string과 React state를 동기화하는 `useQueryState` 훅을 추가합니다.
`useState`와 동일한 인터페이스로 query param을 읽고 쓸 수 있으며, 브라우저 뒤로 가기/앞으로 가기에도 자동으로 반응합니다.

## 관련 이슈


- Closes #16 

## 변경 유형

- [x] 새로운 훅 추가
- [ ] 버그 수정
- [ ] 기존 훅 수정
- [ ] 테스트
- [ ] 문서
- [ ] 설정 / 빌드

## 체크리스트

- [x] 테스트 작성 및 통과 (`pnpm test`)
- [x] 타입 체크 통과 (`pnpm lint`)
- [x] 빌드 통과 (`pnpm build`)
- [x] 신규 훅인 경우 `src/hooks/index.ts`, `src/index.ts`에 export 추가
- [x] Breaking Change가 있는 경우 아래에 명시

## Breaking Change

---

## 릴리즈

<!-- main 브랜치로 머지할 때 작성해주세요. dev 브랜치 PR은 비워두셔도 됩니다. -->

### 버전 업 유형

<!-- 하나만 선택해주세요: patch | minor | major -->
<!-- patch: 버그 수정, 설정 변경 (0.0.x) -->
<!-- minor: 새 훅 추가, 기능 추가 (0.x.0) -->
<!-- major: Breaking Change (x.0.0) -->

```
minor
```

### 변경 내용

<!-- CHANGELOG.md와 GitHub Release에 기록될 내용입니다. -->
<!-- 주요 변경 사항을 bullet로 작성해주세요. -->
- feat: `useQueryState` 훅 추가 — URL query string과 React state를 동기화, `parse`/`serialize`/`history`/`removeOn` 옵션 지원

## useQueryState 사용법
### 기본 - 숫자형 페이지

```ts
import { useQueryState } from 'react-ssutil';

const [page, setPage] = useQueryState('page', 1, {
  parse: (v) => Number(v),
  serialize: (v) => String(v),
});

// URL: /?page=3  →  page === 3
setPage(4);           // URL: /?page=4
setPage((p) => p + 1); // URL: /?page=5

```

### 문자열 검색
```ts
const [search, setSearch] = useQueryState('q', '');
// parse/serialize 생략 가능 (기본값: string 그대로)

setSearch('react hooks'); // URL: /?q=react+hooks
```

### boolean 토글
```ts
const [open, setOpen] = useQueryState('modal', false, {
  parse: (v) => v === 'true',
  serialize: (v) => String(v),
});

// URL: /?modal=true  →  open === true
setOpen(false); // URL: /?modal=false
```

### removeOn - 기본값이면 URL에서 제거
query param이 기본값과 같을 때 URL을 깔끔하게 유지하고 싶을 때 사용
```ts
const [page, setPage] = useQueryState('page', 1, {
  parse: (v) => Number(v),
  serialize: (v) => String(v),
  removeOn: (v) => v === 1, // page=1이면 URL에서 ?page 삭제
});

setPage(1); // URL: / (파라미터 없음)
setPage(3); // URL: /?page=3
```

### history: "push" - 뒤로 가기 히스토리 쌓기
기본값은 "replace" (히스토리 스택을 덮어씀). "push"로 바꾸면 브라우저 뒤로 가기로 이전 값으로 돌아갈 수 있습니다.

```ts
const [tab, setTab] = useQueryState('tab', 'overview', {
  history: 'push', // 탭 이동을 뒤로 가기로 되돌릴 수 있음
});
```

### 여러 query param 동시 사용
각 훅이 독립적으로 동작하고, 서로의 파라미터를 건드리지 않습니다.
```ts
const [page, setPage] = useQueryState('page', 1, { parse: Number });
const [sort, setSort] = useQueryState('sort', 'latest');

setPage(2); // URL: /?sort=latest&page=2  (sort 유지)

```
### 옵션 타입

```ts
interface UseQueryStateOptions<T> {
  parse?: (value: string) => T;     // URL string → T
  serialize?: (value: T) => string; // T → URL string (기본: String(v))
  history?: 'replace' | 'push';    // 기본: 'replace'
  removeOn?: (value: T) => boolean; // true 반환 시 query param 제거
}

```